### PR TITLE
Chain site:rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Drupal console commands
 
-Provides custom Drupal console commands and chains. 
+Provides custom Drupal console commands and chains.
 
 ## Requirements
 - Composer https://getcomposer.org/
@@ -38,8 +38,21 @@ e.g. https://raw.githubusercontent.com/dennisinteractive/drupal_console_commands
 - drupal **site:grunt** *site-name*
 	Runs grunt
 - drupal **site:build**
-	A wrapper that will call all the commands above and do some additional tasks.
-
+	A wrapper that will call all the commands below:
+    - site:checkout
+    - site:rebuild
+- drupal **site:rebuild**
+	A wrapper that will call all the commands below:
+    - site:compose
+    - site:npm
+    - site:grunt
+    - site:settings:db
+    - site:phpunit:setup
+    - site:behat:setup
+    - site:settings:memcache
+    - site:db:import
+    - drush updb
+    - drush cr
 
 # Useful arguments and options
 - **-h** Show all the available arguments and options

--- a/chain/chain-site-build.yml
+++ b/chain/chain-site-build.yml
@@ -9,50 +9,8 @@ commands:
       name: '%{{name}}'
     options:
       branch: '%{{branch|8.x}}'
-# Run composer
-  - command: site:compose
-    arguments:
-      name: '%{{name}}'
-# Run npm
-  - command: site:npm
+# Run site:rebuild
+  - command: site:rebuild
     options:
       placeholder:
         - 'name:%{{name}}'
-# Run grunt
-  - command: site:grunt
-    options:
-      placeholder:
-        - 'name:%{{name}}'
-# Create settings.db.php
-  - command: site:settings:db
-    arguments:
-      name: '%{{name}}'
-# Create phpunit.xml
-  - command: site:phpunit:setup
-    arguments:
-      name: '%{{name}}'
-# Create behat.yml
-  - command: site:behat:setup
-    arguments:
-      name: '%{{name}}'
-# Create settings.memcache.php
-  - command: site:settings:memcache
-    arguments:
-      name: '%{{name}}'
-    options:
-      memcache-prefix: '%{{name}}'
-# Imports db or installs a site
-  - command: site:db:import
-    arguments:
-      name: '%{{name}}'
-      profile: '%{{profile|config_installer}}'
-    options:
-      account-pass: dennis3
-# Run updates
-  - command: exec
-    arguments:
-      bin: 'cd /vagrant/repos/%{{name}}/web; drush updb -y;'
-# Clear cache
-  - command: exec
-    arguments:
-      bin: 'cd /vagrant/repos/%{{name}}/web; drush cr;'

--- a/chain/chain-site-rebuild.yml
+++ b/chain/chain-site-rebuild.yml
@@ -1,0 +1,51 @@
+# Usage: drupal site:rebuild --placeholder="name:subscriptions"
+command:
+  name: site:rebuild
+  description: 'Performs multiple commands to build a site (without git checkout)'
+commands:
+# Run composer
+  - command: site:compose
+    arguments:
+      name: '%{{name}}'
+# Run npm
+  - command: site:npm
+    options:
+      placeholder:
+        - 'name:%{{name}}'
+# Run grunt
+  - command: site:grunt
+    options:
+      placeholder:
+        - 'name:%{{name}}'
+# Create settings.db.php
+  - command: site:settings:db
+    arguments:
+      name: '%{{name}}'
+# Create phpunit.xml
+  - command: site:phpunit:setup
+    arguments:
+      name: '%{{name}}'
+# Create behat.yml
+  - command: site:behat:setup
+    arguments:
+      name: '%{{name}}'
+# Create settings.memcache.php
+  - command: site:settings:memcache
+    arguments:
+      name: '%{{name}}'
+    options:
+      memcache-prefix: '%{{name}}'
+# Imports db or installs a site
+  - command: site:db:import
+    arguments:
+      name: '%{{name}}'
+    options:
+      account-pass: dennis3
+# Run updates
+  - command: exec
+    arguments:
+      bin: 'cd /vagrant/repos/%{{name}}/web; drush updb -y;'
+# Clear cache
+  - command: exec
+    arguments:
+      bin: 'cd /vagrant/repos/%{{name}}/web; drush cr;'


### PR DESCRIPTION
This branch splits site:build into two commands:

1. site:build which runs:
- site:checkout
- site:rebuild

2. site:rebuild which runs:
- site:compose
- site:npm
- site:grunt
- site:settings:db
- site:phpunit:setup
- site:behat:setup
- site:settings:memcache
- site:db:import
- drush updb
- drush cr

In other words, if you want to build the site for the first time or use the command to checkout the repo, use site:build.
If you want to manage the repo yourself, and just want to build the site with the codebase as it is, use site:rebuild.

## Testing
On your VM

1. `cd ~/.console/extend/vendor/dennisdigital`
2. `rm -rf drupal_console_commands`
3. `git clone --branch better_chains git@github.com:dennisinteractive/drupal_console_commands.git`
4. `cp drupal_console_commands/chain/chain-* ~/.console/chain/`

Now you can run the new command.
`drupal site:rebuild`