### PR TITLE
Better interactive mode

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,3 +37,6 @@ composer require dennisdigital/drupal_console_commands:dev-master
 
 # Copy chain commands
 cp vendor/dennisdigital/drupal_console_commands/chain/*.yml ../chain
+
+# Site build script
+sudo ln -s ~/.console/extend/vendor/dennisdigital/drupal_console_commands/scripts/site_build.sh /usr/local/bin/site_build

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,3 +40,4 @@ cp vendor/dennisdigital/drupal_console_commands/chain/*.yml ../chain
 
 # Site build script
 sudo ln -s ~/.console/extend/vendor/dennisdigital/drupal_console_commands/scripts/site_build.sh /usr/local/bin/site_build
+sudo ln -s ~/.console/extend/vendor/dennisdigital/drupal_console_commands/scripts/site_rebuild.sh /usr/local/bin/site_rebuild

--- a/scripts/site_build.sh
+++ b/scripts/site_build.sh
@@ -21,12 +21,12 @@ if [ "$2" = "" ]
 fi
 
 drupal site:compose ${SITENAME} && \
-drupal site:npm --placeholder"name:${SITENAME}" && \
-drupal site:grunt --placeholder"name:${SITENAME}" && \
+drupal site:npm --placeholder="name:${SITENAME}" && \
+drupal site:grunt --placeholder="name:${SITENAME}" && \
 drupal site:settings:db ${SITENAME} && \
 drupal site:phpunit:setup ${SITENAME} && \
 drupal site:behat:setup ${SITENAME} && \
 drupal site:settings:memcache ${SITENAME} && \
 drupal site:db:import ${SITENAME} && \
-cd /vagrant/repos/%{{name}}/web; drush updb -y
-cd /vagrant/repos/%{{name}}/web; drush cr;
+cd /vagrant/repos/${SITENAME}/web; drush updb -y
+cd /vagrant/repos/${SITENAME}/web; drush cr;

--- a/scripts/site_build.sh
+++ b/scripts/site_build.sh
@@ -10,4 +10,5 @@ if [ "$2" = "" ]
     CMD="drupal site:checkout ${SITENAME} -B $2"
 fi
 
+$CMD && \
 site_rebuild ${SITENAME}

--- a/scripts/site_build.sh
+++ b/scripts/site_build.sh
@@ -29,5 +29,5 @@ drupal site:phpunit:setup ${SITENAME} && \
 drupal site:behat:setup ${SITENAME} && \
 drupal site:settings:memcache ${SITENAME} && \
 drupal site:db:import ${SITENAME} && \
-cd /vagrant/repos/${SITENAME}/web; drush updb -y
-cd /vagrant/repos/${SITENAME}/web; drush cr;
+cd /vagrant/repos/${SITENAME}/web && drush updb -y && \
+cd /vagrant/repos/${SITENAME}/web && drush cr

--- a/scripts/site_build.sh
+++ b/scripts/site_build.sh
@@ -15,11 +15,12 @@ SITENAME=$1;
 
 if [ "$2" = "" ]
   then
-    drupal site:checkout ${SITENAME}
+    CMD="drupal site:checkout ${SITENAME}"
   else
-    drupal site:checkout ${SITENAME} -B $2
+    CMD="drupal site:checkout ${SITENAME} -B $2"
 fi
 
+$CMD && \
 drupal site:compose ${SITENAME} && \
 drupal site:npm --placeholder="name:${SITENAME}" && \
 drupal site:grunt --placeholder="name:${SITENAME}" && \

--- a/scripts/site_build.sh
+++ b/scripts/site_build.sh
@@ -1,16 +1,6 @@
 #!/bin/sh
 # Alternative way to using chains
 
-#if [ "$1" = "" ]
-#  then
-#    echo
-#    echo "Syntax: site_build [site-name] [branch]"
-#    echo
-#    echo "You need to specify a site name (without the environment .dev)"
-#    drupal site:debug
-#    exit
-#fi
-
 SITENAME=$1;
 
 if [ "$2" = "" ]
@@ -20,14 +10,4 @@ if [ "$2" = "" ]
     CMD="drupal site:checkout ${SITENAME} -B $2"
 fi
 
-$CMD && \
-drupal site:compose ${SITENAME} && \
-drupal site:npm --placeholder="name:${SITENAME}" && \
-drupal site:grunt --placeholder="name:${SITENAME}" && \
-drupal site:settings:db ${SITENAME} && \
-drupal site:phpunit:setup ${SITENAME} && \
-drupal site:behat:setup ${SITENAME} && \
-drupal site:settings:memcache ${SITENAME} && \
-drupal site:db:import ${SITENAME} && \
-cd /vagrant/repos/${SITENAME}/web && drush updb -y && \
-cd /vagrant/repos/${SITENAME}/web && drush cr
+site_rebuild ${SITENAME}

--- a/scripts/site_build.sh
+++ b/scripts/site_build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Alternative way to using chains
+
+#if [ "$1" = "" ]
+#  then
+#    echo
+#    echo "Syntax: site_build [site-name] [branch]"
+#    echo
+#    echo "You need to specify a site name (without the environment .dev)"
+#    drupal site:debug
+#    exit
+#fi
+
+SITENAME=$1;
+
+if [ "$2" = "" ]
+  then
+    drupal site:checkout ${SITENAME}
+  else
+    drupal site:checkout ${SITENAME} -B $2
+fi
+
+drupal site:compose ${SITENAME} && \
+drupal site:npm --placeholder"name:${SITENAME}" && \
+drupal site:grunt --placeholder"name:${SITENAME}" && \
+drupal site:settings:db ${SITENAME} && \
+drupal site:phpunit:setup ${SITENAME} && \
+drupal site:behat:setup ${SITENAME} && \
+drupal site:settings:memcache ${SITENAME} && \
+drupal site:db:import ${SITENAME} && \
+cd /vagrant/repos/%{{name}}/web; drush updb -y
+cd /vagrant/repos/%{{name}}/web; drush cr;

--- a/scripts/site_rebuild.sh
+++ b/scripts/site_rebuild.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Alternative way to using chains
+
+SITENAME=$1;
+
+drupal site:compose ${SITENAME} && \
+drupal site:npm --placeholder="name:${SITENAME}" && \
+drupal site:grunt --placeholder="name:${SITENAME}" && \
+drupal site:settings:db ${SITENAME} && \
+drupal site:phpunit:setup ${SITENAME} && \
+drupal site:behat:setup ${SITENAME} && \
+drupal site:settings:memcache ${SITENAME} && \
+drupal site:db:import ${SITENAME} && \
+cd /vagrant/repos/${SITENAME}/web && drush updb -y && \
+cd /vagrant/repos/${SITENAME}/web && drush cr

--- a/src/Command/SiteBaseCommand.php
+++ b/src/Command/SiteBaseCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Finder\Finder;
 use Drupal\Console\Core\Style\DrupalStyle;
 use Drupal\Console\Core\Command\Shared\CommandTrait;
 use DennisDigital\Drupal\Console\Exception\SiteCommandException;
@@ -25,6 +26,11 @@ use DennisDigital\Drupal\Console\Exception\SiteCommandException;
  */
 class SiteBaseCommand extends Command {
   use CommandTrait;
+
+  /**
+   * @var ConfigurationManager
+   */
+  protected $configurationManager;
 
   /**
    * IO interface.
@@ -111,6 +117,9 @@ class SiteBaseCommand extends Command {
    */
   protected function interact(InputInterface $input, OutputInterface $output) {
     $this->io = new DrupalStyle($input, $output);
+
+    $this->configurationManager = $this->container
+      ->get('console.configuration_manager');
 
     $name = $input->getArgument('name');
     if (!$name) {


### PR DESCRIPTION
Two new features:

The drupal console comands used to build the site will now show a list of available sites instead of asking you to type the site name.
![screen shot 2017-01-27 at 10 36 35](https://cloud.githubusercontent.com/assets/2162363/22368939/1191d64c-e481-11e6-87ed-8a1cf9e44f95.png)

drupal site:checkout will now display the list of branches for you to select. If you select the same branch (or hit enter) it will not complain about uncommitted changes.
![screen shot 2017-01-27 at 10 36 53](https://cloud.githubusercontent.com/assets/2162363/22368966/285b5b32-e481-11e6-9e65-e67d249a620f.png)

## Testing
On your VM

1. `cd ~/.console/extend/vendor/dennisdigital`
2. `rm -rf drupal_console_commands`
3. `git clone --branch better_interactive_mode git@github.com:dennisinteractive/drupal_console_commands.git`
4. `sudo ln -s ~/.console/extend/vendor/dennisdigital/drupal_console_commands/scripts/site_build.sh /usr/local/bin/site_build`
5. `sudo ln -s ~/.console/extend/vendor/dennisdigital/drupal_console_commands/scripts/site_rebuild.sh /usr/local/bin/site_rebuild`

Now you can run the commands, i.e.
`drupal site:checkout`

**PS: These new features only work on interactive mode, they won't work with chains**

On the other hand you can use the experimental bash script, by running:
`site_build`

or with site name i.e.
`site_build subscriptions`

you can also specify the branch to have full build without questions
`site_build subscriptions 8.x`

and finally
`site_rebuild` if you want to skip the checkout bit.
