### PR TITLE
Setting UUID from system.site yml file

### DIFF
--- a/src/Command/SiteBaseCommand.php
+++ b/src/Command/SiteBaseCommand.php
@@ -214,7 +214,7 @@ class SiteBaseCommand extends Command {
       $this->profile = $input->getArgument('profile');
     }
     elseif (isset($this->config['profile'])) {
-      // Use config from sites.yml.
+      // Use config from ~/.console/sites/{site}.yml.
       $this->profile = $this->config['profile'];
     }
     else {

--- a/src/Command/SiteDbImportCommand.php
+++ b/src/Command/SiteDbImportCommand.php
@@ -226,7 +226,17 @@ class SiteDbImportCommand extends SiteBaseCommand {
       throw new SiteCommandException($shellProcess->getOutput());
     }
 
-    // Update site uuid from config if installing a new site.
+    // Update site uuid.
+    $this->setSiteUUID();
+  }
+
+  /**
+   * Updates the site UUID if installing a new site.
+   *
+   * @throws \DennisDigital\Drupal\Console\Exception\SiteCommandException
+   */
+  protected function setSiteUUID() {
+    $shellProcess = $this->getShellProcess();
     if (!$this->fileExists($this->filename)) {
       $command = sprintf(
         'cd %s && ' .


### PR DESCRIPTION
@marcelovani / @kalpaitch setting the UUID from system.site yml config file when installing new site.

Uses drush `config-set` and `config-get`.

To test
- Update the site yml file to use the actual profile: `profile: dennis_profile`
- Add `uuid: c830d5b0-d77f-4600-8324-7be2e287f770` to system.site.yml

If this works, we can remove config installer patch from core