### PR TITLE
Use timestamp

### DIFF
--- a/chain/chain-site-rebuild.yml
+++ b/chain/chain-site-rebuild.yml
@@ -33,8 +33,6 @@ commands:
   - command: site:settings:memcache
     arguments:
       name: '%{{name}}'
-    options:
-      memcache-prefix: '%{{name}}'
 # Imports db or installs a site
   - command: site:db:import
     arguments:

--- a/src/Command/SiteSettingsMemcacheCommand.php
+++ b/src/Command/SiteSettingsMemcacheCommand.php
@@ -73,7 +73,7 @@ class SiteSettingsMemcacheCommand extends SiteBaseCommand {
     }
 
     if (is_null($input->getOption('memcache-prefix'))) {
-      $input->setOption('memcache-prefix', $this->siteName);
+      $input->setOption('memcache-prefix', $this->siteName . '_' . microtime(true));
     }
 
     // Remove existing file.


### PR DESCRIPTION
To test
on your vm
`cd ~/.console/extend/vendor/dennisdigital/drupal_console_commands`
`git checkout memcache_prefix_fix`
`drupal site:settings:memcache subscriptions`
then check vagrant/repos/subscriptions/web/sites/default/settings.memcache.php
it should contain a timestamp on the memcache prefix 
After merging the PR, please create a new tag for devops