### PR TITLE
Update chain-site-rebuild.yml

### DIFF
--- a/chain/chain-site-rebuild.yml
+++ b/chain/chain-site-rebuild.yml
@@ -37,6 +37,10 @@ commands:
   - command: site:db:import
     arguments:
       name: '%{{name}}'
+# Set default drush alias
+  - command: exec
+    arguments:
+      bin: 'cd /vagrant/repos/%{{name}}/web; drush site-set @vm;'
 # Import configuration
   - command: exec
     arguments:


### PR DESCRIPTION
Related to case 26684; https://didev.fogbugz.com/f/cases/26684/Setup-aliases

Default content tests required elevated drush permissions, there is a new alias in the subscriptions site, so now we only need to run `drush site-set @vm` and all future commands will run as user 1.