### PR TITLE
Run updatedb before cim

### DIFF
--- a/chain/chain-site-rebuild.yml
+++ b/chain/chain-site-rebuild.yml
@@ -45,6 +45,10 @@ commands:
   - command: exec
     arguments:
       bin: 'cd /vagrant/repos/%{{name}}/web; drush site-set @vm;'
+# Run db updates
+  - command: exec
+    arguments:
+      bin: 'cd /vagrant/repos/%{{name}}/web; drush updb -y;'
 # Import configuration
   - command: exec
     arguments:


### PR DESCRIPTION
Fix done in chain-site-rebuild.yml as part of 27549, where I was getting this error:

Error Output:                                                                              
  ================                                                                           
  Drupal\Core\Config\ConfigImporterException: There were errors        [error]               
  validating the config synchronization. in                                                  
  Drupal\Core\Config\ConfigImporter->validate() (line 728 of                                 
  /vagrant/repos/subscriptions/web/core/lib/Drupal/Core/Config/ConfigImporter.php).          
  The import failed due for the following reasons:                     [error]               
  Cannot change the install profile from <em                                                 
  class="placeholder">dennis_profile</em> to <em                                             
  class="placeholder"></em> once Drupal is installed.                                        
  Drupal\Core\Entity\Exception\UnsupportedEntityTypeDefinitionException:[error]              
  The entity type node does not have a "published" entity key. in                            
  Drupal\node\Entity\Node::publishedBaseFieldDefinitions() (line 32 of                       
  /vagrant/repos/subscriptions/web/core/lib/Drupal/Core/Entity/EntityPublishedTrait.php).  