### PR TITLE
Case 27610; Add drush cr command to drupal console command chain for …

### DIFF
--- a/chain/chain-site-rebuild.yml
+++ b/chain/chain-site-rebuild.yml
@@ -41,6 +41,10 @@ commands:
   - command: site:db:import
     arguments:
       name: '%{{name}}'
+# Clear cache
+  - command: exec
+    arguments:
+      bin: 'cd /vagrant/repos/%{{name}}/web; drush cr;'
 # Set default drush alias
   - command: exec
     arguments:


### PR DESCRIPTION
…site:rebuild. This is to clear an error that is occuring when upgrading to 8.3 from 8.2 DB dump