### PR TITLE
27657 cdn

### DIFF
--- a/chain/chain-site-rebuild.yml
+++ b/chain/chain-site-rebuild.yml
@@ -21,10 +21,10 @@ commands:
   - command: site:settings:db
     arguments:
       name: '%{{name}}'
-# Enable development settings
-  - command: exec
+# Create settings.local.php
+  - command: site:settings:local
     arguments:
-      bin: 'cd /vagrant/repos/%{{name}}/web/sites; cp -n ./example.settings.local.php ./default/settings.local.php;'
+      name: '%{{name}}'
 # Create phpunit.xml
   - command: site:phpunit:setup
     arguments:

--- a/console.config.yml
+++ b/console.config.yml
@@ -10,6 +10,8 @@ application:
           class: \DennisDigital\Drupal\Console\Command\SiteSettingsDbCommand
         'site:settings:memcache':
           class: \DennisDigital\Drupal\Console\Command\SiteSettingsMemcacheCommand
+        'site:settings:local':
+          class: \DennisDigital\Drupal\Console\Command\SiteSettingsLocalCommand
         'site:db:import':
           class: \DennisDigital\Drupal\Console\Command\SiteDbImportCommand
         'site:behat:setup':

--- a/src/Command/SiteCheckoutCommand.php
+++ b/src/Command/SiteCheckoutCommand.php
@@ -302,8 +302,6 @@ class SiteCheckoutCommand extends SiteBaseCommand {
   /**
    * Pulls a list of branches from remote.
    *
-   * @param $repo
-   *
    * @return mixed
    * @throws SiteCommandException
    */

--- a/src/Command/SiteSettingsLocalCommand.php
+++ b/src/Command/SiteSettingsLocalCommand.php
@@ -86,14 +86,17 @@ class SiteSettingsLocalCommand extends SiteBaseCommand {
     // Load the file.
     $content = $this->fileGetContents($file);
 
+    $host= $this->config['host'];
+    $cdn = $this->config['cdn'];
+
     // Append configuration.
     $content .= <<<EOF
 
 // Set Stage file proxy origin.
-\$config['stage_file_proxy.settings']['origin'] = 'cdn.subscriptions.dennis.co.uk';
+\$config['stage_file_proxy.settings']['origin'] = '$cdn';
 
 // Change CDN domain to local.
-\$config['cdn.settings']['mapping']['domain'] = 'subscriptions.vm8.didev.co.uk';
+\$config['cdn.settings']['mapping']['domain'] = '$host';
 
 EOF;
 

--- a/src/Command/SiteSettingsLocalCommand.php
+++ b/src/Command/SiteSettingsLocalCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @file
+ * Contains \DennisDigital\Drupal\Console\Command\SiteSettingsLocalCommand.
+ *
+ * Creates Local configurations.
+ */
+
+namespace DennisDigital\Drupal\Console\Command;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use DennisDigital\Drupal\Console\Exception\SiteCommandException;
+
+/**
+ * Class SiteSettingsLocalCommand
+ *
+ * @package DennisDigital\Drupal\Console\Command
+ */
+class SiteSettingsLocalCommand extends SiteBaseCommand {
+
+  /**
+   * The file name to generate.
+   *
+   * @var
+   */
+  protected $filename = 'settings.local.php';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    parent::configure();
+
+    $this->setName('site:settings:local')
+      // @todo use: ->setDescription($this->trans('commands.site.settings.local.description'))
+      ->setDescription('Generates settings.local.php for a given site.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function interact(InputInterface $input, OutputInterface $output) {
+    parent::interact($input, $output);
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    parent::execute($input, $output);
+
+    $this->destination = $this->settingsPhpDirectory();
+
+    // Validation.
+    if (!$this->fileExists($this->destination . '../example.' . $this->filename)) {
+      $message = sprintf('The file example.settings.local.php is missing.',
+        $this->destination
+      );
+      throw new SiteCommandException($message);
+    }
+
+    // Remove existing file.
+    $file = $this->destination . $this->filename;
+    if ($this->fileExists($file)) {
+      $this->fileUnlink($file);
+    }
+
+    // Copy example.
+    $command = sprintf('cd %s && cp -n ../example.%s %s',
+      $this->shellPath($this->destination),
+      $this->filename,
+      $this->filename
+    );
+    $shellProcess = $this->getShellProcess();
+    if (!$shellProcess->exec($command, TRUE)) {
+      throw new SiteCommandException(sprintf('Error generating %s',
+          $this->filename
+        )
+      );
+    }
+
+    // Load the file.
+    $content = $this->fileGetContents($file);
+
+    // Append configuration.
+    $content .= <<<EOF
+
+// Set Stage file proxy origin.
+\$config['stage_file_proxy.settings']['origin'] = 'cdn.subscriptions.dennis.co.uk';
+
+// Change CDN domain to local.
+\$config['cdn.settings']['mapping']['domain'] = 'subscriptions.vm8.didev.co.uk';
+
+EOF;
+
+    $this->filePutContents($file, $content);
+
+    // Check file.
+    if ($this->fileExists($file)) {
+      $this->io->success(sprintf('Generated %s',
+          $file)
+      );
+    }
+    else {
+      throw new SiteCommandException(sprintf('Error generating %s',
+          $file
+        )
+      );
+    }
+  }
+}


### PR DESCRIPTION
Created a new custom command to replace the bash on the chain

This command will:

1 - Copy **example.settings.local.php** into the sites/default as **settings.local.php**
2 - Append Stage file proxy and CDN overrides

Testing:
1 - Edit ~/.console/sites/subscriptions.yml and add: `cdn: cdn.subscriptions.dennis.co.uk`
2 - Edit ~/.console/extend/extend.yml and add
```
'site:settings:local':
          class: \DennisDigital\Drupal\Console\Command\SiteSettingsLocalCommand
```

3 - Run `drupal site:settings:local subscriptions`
4 - Check that settings.local.php was created and the overrides are present.

For Devops:
Alter subscriptions.yml and add: `cdn: cdn.subscriptions.dennis.co.uk`
Make sure the drupal commands will pick these changes during provisioning
Devops don't have to call this command if they prefer to use their own templates to add the overrides onto **settings.local.php**
ps : These overrides are only for **Non production** environments
