### PR TITLE
27790 console updates

### DIFF
--- a/chain/chain-site-compile-artifact.yml
+++ b/chain/chain-site-compile-artifact.yml
@@ -1,4 +1,4 @@
-# Usage: drupal site:compile:prod --placeholder="name:subscriptions" --placeholder="root:/vagrant/repos"
+# Usage: drupal site:compile:artifact --placeholder="name:subscriptions" --placeholder="root:/vagrant/repos"
 command:
   name: site:compile:artifact
   description: 'Compiles the source, downloading and extracting the packages.'

--- a/chain/chain-site-compile-artifact.yml
+++ b/chain/chain-site-compile-artifact.yml
@@ -1,0 +1,19 @@
+# Usage: drupal site:compile:prod --placeholder="name:subscriptions" --placeholder="root:/vagrant/repos"
+command:
+  name: site:compile:artifact
+  description: 'Compiles the source, downloading and extracting the packages.'
+commands:
+# Run composer
+  - command: site:compose
+    arguments:
+      name: '%{{name}}'
+    options:
+      destination-directory: '%{{root|/vagrant/repos}}'
+# Run npm
+  - command: exec
+    arguments:
+      bin: 'cd %{{root|/vagrant/repos}}/web; find . -type d \( -name node_modules -o -name contrib -o -path ./core \) -prune -o -name package.json -execdir sh -c "npm install" \;'
+# Run grunt
+  - command: exec
+    arguments:
+      bin: 'cd %{{root|/vagrant/repos}}/web; find . -type d \( -name node_modules -o -name contrib -o -path ./core \) -prune -o -name Gruntfile.js -execdir sh -c "grunt" \;'

--- a/chain/chain-site-test.yml
+++ b/chain/chain-site-test.yml
@@ -1,4 +1,4 @@
-# Usage: drupal site:test --placeholder="name:subscriptions" --placeholder="root:/vagrant/repos"
+# Usage: drupal site:test --placeholder="name:subscriptions" --placeholder="root:/vagrant/repos" --placeholder="tags:tags"
 command:
   name: site:test
   description: 'Sets the test suites up and then runs them.'
@@ -14,7 +14,7 @@ commands:
 # Run Behat
   - command: exec
     arguments:
-      bin: 'cd %{{root|/vagrant/repos}}/%{{name}}/tests; ./behat;'
+      bin: 'cd %{{root|/vagrant/repos}}/%{{name}}/tests; ./behat --tags="%{{tags}}";'
 # Run phpunit
   - command: exec
     arguments:

--- a/chain/chain-site-test.yml
+++ b/chain/chain-site-test.yml
@@ -1,4 +1,4 @@
-# Usage: drupal site:test --placeholder="name:subscriptions" --placeholder="root:/vagrant/repos" --placeholder="tags:tags"
+# Usage: drupal site:test --placeholder="name:subscriptions" --placeholder="root:/vagrant/repos" --placeholder="behat_params:--tags=bannerimage"
 command:
   name: site:test
   description: 'Sets the test suites up and then runs them.'
@@ -14,7 +14,7 @@ commands:
 # Run Behat
   - command: exec
     arguments:
-      bin: 'cd %{{root|/vagrant/repos}}/%{{name}}/tests; ./behat --tags="%{{tags}}";'
+      bin: 'cd %{{root|/vagrant/repos}}/%{{name}}/tests; ./behat %{{behat_params|-n}};'
 # Run phpunit
   - command: exec
     arguments:


### PR DESCRIPTION
-I've created a new command: drupal **site:compile:artifact**, which doesn't create the site name folder.
-I've updated the command: drupal **site:test**, so now it's possible to pass behat parameters (optional). Example:
--placeholder="behat_params:--tags=bannerimage"
