### PR TITLE
Downloaddb replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ e.g. https://raw.githubusercontent.com/dennisinteractive/drupal_console_commands
 
 - drupal **site:settings:local** *site-name*
 	Creates *settings.local.php* in the *web/sites/default* folder. This file contains local settings overrides and should not be committed.
+	If you have a file named `example.settings.local.php` on the site's folder, it will be used as a template for settings.local.php.
 
 - drupal **site:settings:memcache** *site-name*
 	Creates *settings.memcache.php* in the *web/sites/default* folder. This file contains Memcache configuration and should not be committed.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ e.g. https://raw.githubusercontent.com/dennisinteractive/drupal_console_commands
 - drupal **site:compose** *site-name*
 	Runs *composer*
 
+- drupal **site:make** *site-name*
+	Runs *drush make*
+
 - drupal **site:npm**
   Runs NPM
 

--- a/chain/chain-site-build7.yml
+++ b/chain/chain-site-build7.yml
@@ -1,0 +1,16 @@
+# Usage: drupal site:build7 --placeholder="name:subscriptions"
+command:
+  name: site:build7
+  description: 'Builds a Drupal 7 site using make file.'
+commands:
+# Checkout site
+  - command: site:checkout
+    arguments:
+      name: '%{{name}}'
+    options:
+      branch: '%{{branch|8.x}}'
+# Run site:rebuild
+  - command: site:rebuild7
+    options:
+      placeholder:
+        - 'name:%{{name}}'

--- a/chain/chain-site-rebuild7.yml
+++ b/chain/chain-site-rebuild7.yml
@@ -1,0 +1,35 @@
+# Usage: drupal site:rebuild7 --placeholder="name:subscriptions"
+command:
+  name: site:rebuild7
+  description: 'Performs necessary steps to rebuild the site from a given source using make file.'
+commands:
+# Run drush make.
+  - command: site:make
+    arguments:
+      name: '%{{name}}'
+# Run NPM.
+  - command: site:npm
+    arguments:
+      name: '%{{name}}'
+# Run Grunt.
+  - command: site:grunt
+    arguments:
+      name: '%{{name}}'
+# Generate the settings.
+  - command: site:configure
+    options:
+      placeholder:
+        - 'name:%{{name}}'
+# Tests setup.
+#  - command: site:test:setup
+#    options:
+#      placeholder:
+#        - 'name:%{{name}}'
+# Imports db or installs a site
+  - command: site:db:import
+    arguments:
+      name: '%{{name}}'
+# Run updates.
+  - command: site:update
+    arguments:
+      name: '%{{name}}'

--- a/console.config.yml
+++ b/console.config.yml
@@ -10,6 +10,8 @@ application:
           class: \DennisDigital\Drupal\Console\Command\Site\Checkout\BranchCommand
         'site:compose':
           class: \DennisDigital\Drupal\Console\Command\Site\ComposeCommand
+        'site:make':
+          class: \DennisDigital\Drupal\Console\Command\Site\MakeCommand
         'site:settings:db':
           class: \DennisDigital\Drupal\Console\Command\Site\Settings\DbCommand
         'site:settings:memcache':

--- a/src/Command/Drupal/Detector.php
+++ b/src/Command/Drupal/Detector.php
@@ -37,6 +37,7 @@ class Detector {
     if (!file_exists($drupalRoot)) {
       return;
     }
+    $version = '';
     $this->drupalRoot = $drupalRoot;
 
     if (!isset($this->version)) {
@@ -54,6 +55,7 @@ class Detector {
           require_once $this->drupalRoot . $path;
         }
       }
+
       if (defined('VERSION')) {
         $version = VERSION;
       }
@@ -61,7 +63,12 @@ class Detector {
         $version = \Drupal::VERSION;
       }
       else {
-        throw new \Exception('Unable to determine Drupal core version. Supported versions are 7, and 8.');
+        // Could not find core. One last try.
+        // A bit magic but that is it for now.
+        $result = explode('/sites/', $drupalRoot);
+        if (is_array($result)) {
+          $version = $this->getDrupalVersion($result[0]);
+        }
       }
 
       // Extract the major version from VERSION.

--- a/src/Command/Site/AbstractCommand.php
+++ b/src/Command/Site/AbstractCommand.php
@@ -189,7 +189,9 @@ abstract class AbstractCommand extends Command {
     $this->validateSiteParams($input, $output);
 
     $detector = new Detector();
-    $this->drupalVersion = $detector->getDrupalVersion($this->getWebRoot());
+    if ($this->drupalVersion = $detector->getDrupalVersion($this->getWebRoot())) {
+      $this->io->comment(sprintf('Drupal %s detected.', $this->drupalVersion));
+    }
   }
 
   /**
@@ -330,6 +332,7 @@ abstract class AbstractCommand extends Command {
   protected function validateWebRoot() {
     $web_directory = empty($this->config['web_directory']) ? 'web' : $this->config['web_directory'];
     $this->webRoot = $this->getRoot() . trim($web_directory, '/') . '/';
+    $this->webRoot = str_replace('//', '/', $this->webRoot);
   }
 
   /**
@@ -397,8 +400,16 @@ abstract class AbstractCommand extends Command {
    * @return string Path
    */
   public function validateSiteRoot() {
-    $webSitesPath = $this->getWebRoot() . 'sites/';
-    $settingsPath = $webSitesPath . 'default';
+    // Support for sites that live in docroot/sites/sitename.
+    if ($this->config['web_directory'] == '/') {
+      $webSitesPath = $this->getWebRoot();
+      $settingsPath = $webSitesPath;
+    }
+    else {
+      // Support for sites that live in docroot/web.
+      $webSitesPath = $this->getWebRoot() . 'sites/';
+      $settingsPath = $webSitesPath . 'default';
+    }
 
     // It's possible that a command is run before the site is available. e.g. checkout
     // We will skip setting in this situation, but throw an Exception in the site root getter to prevent any unpredictable behaviour.

--- a/src/Command/Site/DbImportCommand.php
+++ b/src/Command/Site/DbImportCommand.php
@@ -153,7 +153,7 @@ class DbImportCommand extends AbstractCommand {
       //@todo Use drupal site:install instead of Drush.
       $this->io->comment('Installing site');
       // Site install.
-      $commands[] = sprintf('cd %s', $this->shellPath($this->getSiteRoot()));
+      $commands[] = sprintf('cd %s', $this->shellPath($this->getWebRoot()));
       // Install site.
       $commands[] = sprintf('drush si -y %s %s', $this->profile, $options);
       // Drupal 8 only;
@@ -169,7 +169,7 @@ class DbImportCommand extends AbstractCommand {
         $input->setOption('db-name', $this->siteName);
       }
 
-      $commands[] = sprintf('cd %s', $this->shellPath($this->getSiteRoot()));
+      $commands[] = sprintf('cd %s', $this->shellPath($this->getWebRoot()));
       // Create DB;
       $commands[] = sprintf('drush sql-create %s -y', $input->getOption('db-name'));
       // Import dump;

--- a/src/Command/Site/DbImportCommand.php
+++ b/src/Command/Site/DbImportCommand.php
@@ -15,7 +15,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Aws\S3\S3Client;
 use DennisDigital\Drupal\Console\Command\Exception\CommandException;
 use DennisDigital\Drupal\Console\Command\Site\Shared\InstallArgumentsTrait;
-
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 /**
  * Class DbImportCommand
  *
@@ -243,30 +244,19 @@ class DbImportCommand extends AbstractCommand {
         throw new CommandException($shellProcess->getOutput());
       }
     }
-    // For all other methods including remote and local files
-    // we copy chunk by chunk to the local destination.
+    // Copy from file system or mount.
     else {
       // Check the file isn't already downloaded.
       $this->io->write(sprintf('Checking if db dump needs updating:'));
-      if ($this->fileExists($this->tmpFolder . $basename) && md5_file($this->tmpFolder . $basename) === md5_file($filename)) {
+      if ($this->fileExists($this->tmpFolder . $basename) && filemtime($this->tmpFolder . $basename) === filemtime($filename)) {
         $this->io->comment('No');
       }
       else {
-        $this->io->comment('Yes');
-        // Open a stream in read-only mode
-        if ($this->fileExists($filename) && $stream = fopen($filename, 'r')) {
-          // Open the destination file to save the output to.
-          $output_file = fopen($this->tmpFolder . $basename, "a");
-          if ($output_file) {
-            while (!feof($stream)) {
-              fwrite($output_file, fread($stream, 1024), 1024);
-            }
-          }
-          fclose($stream);
-          if ($output_file) {
-            fclose($output_file);
-          }
-        }
+        $this->io->comment('Yes man');
+        // By default copy() checks if the file has been modified before copying.
+        // https://symfony.com/doc/current/components/filesystem.html#copy
+        $fs = new Filesystem();
+        $fs->copy($filename, $this->tmpFolder . $basename);
       }
     }
 

--- a/src/Command/Site/DbImportCommand.php
+++ b/src/Command/Site/DbImportCommand.php
@@ -290,7 +290,10 @@ class DbImportCommand extends AbstractCommand {
     $baseNameSql = rtrim($baseNameGz, '.gz');
 
     // Unzip sql file and keep zipped in the folder.
-    if (mime_content_type($this->filename) === 'application/x-gzip') {
+    if ((function_exists('mime_content_type') &&
+      mime_content_type($this->filename) === 'application/x-gzip') ||
+      strpos($this->filename, '.sql.gz') !== FALSE
+    ) {
       $command = sprintf(
         'cd %s; ' .
         'gunzip -c %s > %s; ',

--- a/src/Command/Site/DbImportCommand.php
+++ b/src/Command/Site/DbImportCommand.php
@@ -152,8 +152,9 @@ class DbImportCommand extends AbstractCommand {
     if (empty($this->filename) || !$this->fileExists($this->filename)) {
       //@todo Use drupal site:install instead of Drush.
       $this->io->comment('Installing site');
-      // Site install.
       $commands[] = sprintf('cd %s', $this->shellPath($this->getWebRoot()));
+      // Create DB;
+      $commands[] = sprintf('drush sql-create -y');
       // Install site.
       $commands[] = sprintf('drush si -y %s %s', $this->profile, $options);
       // Drupal 8 only;
@@ -171,7 +172,7 @@ class DbImportCommand extends AbstractCommand {
 
       $commands[] = sprintf('cd %s', $this->shellPath($this->getWebRoot()));
       // Create DB;
-      $commands[] = sprintf('drush sql-create %s -y', $input->getOption('db-name'));
+      $commands[] = sprintf('drush sql-create -y');
       // Import dump;
       $commands[] = sprintf('drush sql-cli < %s', $this->filename);
     }

--- a/src/Command/Site/DbImportCommand.php
+++ b/src/Command/Site/DbImportCommand.php
@@ -248,11 +248,11 @@ class DbImportCommand extends AbstractCommand {
     else {
       // Check the file isn't already downloaded.
       $this->io->write(sprintf('Checking if db dump needs updating:'));
-      if ($this->fileExists($this->tmpFolder . $basename) && filemtime($this->tmpFolder . $basename) === filemtime($filename)) {
+      if ($this->fileExists($this->tmpFolder . $basename) && filesize($this->tmpFolder . $basename) === filesize($filename)) {
         $this->io->comment('No');
       }
       else {
-        $this->io->comment('Yes man');
+        $this->io->comment('Yes');
         // By default copy() checks if the file has been modified before copying.
         // https://symfony.com/doc/current/components/filesystem.html#copy
         $fs = new Filesystem();

--- a/src/Command/Site/MakeCommand.php
+++ b/src/Command/Site/MakeCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @file
+ * Contains \DennisDigital\Drupal\Console\Command\Site\MakeCommand.
+ *
+ * Runs site make.
+ */
+
+namespace DennisDigital\Drupal\Console\Command\Site;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use DennisDigital\Drupal\Console\Command\Exception\CommandException;
+
+/**
+ * Class MakeCommand
+ *
+ * @package DennisDigital\Drupal\Console\Command
+ */
+class MakeCommand extends AbstractCommand {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    parent::configure();
+
+    $this->setName('site:make')
+      ->setDescription('Runs site make');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function interact(InputInterface $input, OutputInterface $output) {
+    parent::interact($input, $output);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    parent::execute($input, $output);
+
+    if (!$this->fileExists($this->getRoot() . 'site.make')) {
+      $message = sprintf('The file sote.make is missing on %s',
+        $this->getRoot()
+      );
+      throw new CommandException($message);
+    }
+
+    // Run composer install.
+    $this->runCommand('make');
+  }
+
+  /**
+   * Helper to run drush commands.
+   *
+   * @param $command The command to run.
+   *
+   * @return bool TRUE If successful.
+   *
+   * @throws CommandException
+   */
+  protected function runCommand($command) {
+    $command = sprintf(
+      'cd %s && drush %s',
+      $this->shellPath($this->getRoot()),
+      $command
+    );
+    $this->io->commentBlock($command);
+
+    $shellProcess = $this->getShellProcess();
+
+    //@todo Show a progress bar.
+    if ($shellProcess->exec($command, TRUE)) {
+      $this->io->success(sprintf('Site built on %s', $this->getRoot()));
+    }
+    else {
+      throw new CommandException($shellProcess->getOutput());
+    }
+
+    return TRUE;
+  }
+}

--- a/src/Command/Site/MakeCommand.php
+++ b/src/Command/Site/MakeCommand.php
@@ -44,7 +44,7 @@ class MakeCommand extends AbstractCommand {
     parent::execute($input, $output);
 
     if (!$this->fileExists($this->getRoot() . 'site.make')) {
-      $message = sprintf('The file sote.make is missing on %s',
+      $message = sprintf('The file site.make is missing on %s',
         $this->getRoot()
       );
       throw new CommandException($message);

--- a/src/Command/Site/MakeCommand.php
+++ b/src/Command/Site/MakeCommand.php
@@ -50,8 +50,8 @@ class MakeCommand extends AbstractCommand {
       throw new CommandException($message);
     }
 
-    // Run composer install.
-    $this->runCommand('make');
+    // Run drush command.
+    $this->runCommand('make -y --working-copy --no-core --contrib-destination=. site.make');
   }
 
   /**

--- a/src/Command/Site/Settings/DbCommand.php
+++ b/src/Command/Site/Settings/DbCommand.php
@@ -70,6 +70,7 @@ class DbCommand extends AbstractCommand {
     $override = array(
       'db-name' => $this->config['db']['name'],
       'db-user' => $this->config['db']['user'],
+      'db-pass' => $this->config['db']['pass'],
       'db-host' => $this->config['db']['host'],
       'db-port' => $this->config['db']['port'],
       'db-type' => $this->config['db']['type'],

--- a/src/Command/Site/Settings/LocalCommand.php
+++ b/src/Command/Site/Settings/LocalCommand.php
@@ -58,8 +58,8 @@ class LocalCommand extends AbstractCommand {
     $file = $this->getSiteRoot() . $this->filename;
 
     if (!$this->fileExists($exampleFile)) {
-      $message = sprintf('Cannot find %s.', $exampleFile);
-      throw new CommandException($message);
+      $this->io->writeln(sprintf('Cannot find %s. Moving on.', $exampleFile));
+      return;
     }
 
     // Remove existing file.

--- a/src/Command/Site/Settings/LocalCommand.php
+++ b/src/Command/Site/Settings/LocalCommand.php
@@ -59,7 +59,9 @@ class LocalCommand extends AbstractCommand {
 
     if (!$this->fileExists($exampleFile)) {
       $this->io->writeln(sprintf('Cannot find %s. Moving on.', $exampleFile));
-      return;
+      // Create one.
+      $exampleFile = '/tmp/example.' . $this->filename;
+      $this->filePutContents($exampleFile, "<?php\n/**\n * This file was generated automatically.\n*/");
     }
 
     // Remove existing file.

--- a/src/Command/Site/UpdateCommand.php
+++ b/src/Command/Site/UpdateCommand.php
@@ -55,10 +55,10 @@ class UpdateCommand extends AbstractCommand {
     if ($this->drupalVersion === 7) {
       $commands[] = 'drush vset maintenance_mode 1';
       $commands[] = 'drush rr';
-      $commands[] = 'drush cc all';
+      //$commands[] = 'drush cc all';
       $commands[] = 'drush updb -y';
       $commands[] = 'drush rr';
-      $commands[] = 'drush cc all';
+      //$commands[] = 'drush cc all';
       $commands[] = 'drush vset maintenance_mode 0';
     }
 


### PR DESCRIPTION
This PR makes it possible to run Drupal console commands on Drupal 7
- Added drupal core detection mechanism
- Created templates to be included on the respective drupal core version
- Created custom chains for drupal 7
- Created site:make to be used instead of composer