### PR TITLE
Case 29751; use DB name from settings.php

### DIFF
--- a/src/Command/SiteDbImportCommand.php
+++ b/src/Command/SiteDbImportCommand.php
@@ -169,10 +169,9 @@ class SiteDbImportCommand extends SiteBaseCommand {
       }
       $command = sprintf(
         'cd %s; ' .
-        'drush sql-create %s -y; ' .
+        'drush sql-create -y; ' .
         'drush sql-cli < %s; ',
         $this->destination,
-        $input->getOption('db-name'),
         $this->filename
       );
       $this->io->comment('Importing dump');


### PR DESCRIPTION
Starting pull request to unblock Case 29516 in the simplest way (Case 29637 has been created to roll out the latest console command improvements)

I looked at the current deploy/puppet scripts, and couldn't see why removing the db name argument would affect staging builds.

If we passed in the db name as option, it would take the db name from the site yml file (managed by DevOps), which is how settings.php is currently generated.

If there is another known reason that this approach wouldn't work, please update this PR with the explanation so that we can resolve accordingly.

We can merge into `0.48.x` and create new tag `0.48.0.1` for DevOps to use until we resolve Case 29637.